### PR TITLE
feat: add sort by remote address

### DIFF
--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -38,6 +38,8 @@ func sortFieldLabel(f collector.SortField) string {
 		return "state"
 	case collector.SortByProto:
 		return "proto"
+	case collector.SortByRaddr:
+		return "remote"
 	default:
 		return "port"
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -276,6 +276,7 @@ func (m *model) cycleSort() {
 		collector.SortByPID,
 		collector.SortByState,
 		collector.SortByProto,
+		collector.SortByRaddr,
 	}
 
 	for i, f := range fields {


### PR DESCRIPTION
## Summary
- Adds remote address (Raddr) as a sortable field
- Users can now cycle through sort options to sort by remote address

Closes #21