### PR TITLE
feat: display process command line arguments and cwd

### DIFF
--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -6,6 +6,8 @@ type Connection struct {
 	TS         time.Time `json:"ts"`
 	PID        int       `json:"pid"`
 	Process    string    `json:"process"`
+	Cmdline    string    `json:"cmdline"`
+	Cwd        string    `json:"cwd"`
 	User       string    `json:"user"`
 	UID        int       `json:"uid"`
 	Proto      string    `json:"proto"`

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -302,6 +302,8 @@ func (m model) renderDetail() string {
 	}{
 		{"process", c.Process},
 		{"pid", fmt.Sprintf("%d", c.PID)},
+		{"cmdline", c.Cmdline},
+		{"cwd", c.Cwd},
 		{"user", c.User},
 		{"protocol", c.Proto},
 		{"state", c.State},


### PR DESCRIPTION
## Summary
- Adds full command line arguments (cmdline) to Connection struct
- Adds current working directory (cwd) to Connection struct
- macOS: Uses sysctl KERN_PROCARGS2 for full cmdline and proc_pidinfo for cwd
- Linux: Reads /proc/{pid}/cmdline and /proc/{pid}/cwd
- Detail view now shows cmdline and cwd fields

Closes #20