### PR TITLE
feat: add port search, remote sort, export, and process info

### DIFF
--- a/internal/collector/collector_linux.go
+++ b/internal/collector/collector_linux.go
@@ -125,6 +125,8 @@ func GetAllConnections() ([]Connection, error) {
 type processInfo struct {
 	pid     int
 	command string
+	cmdline string
+	cwd     string
 	uid     int
 	user    string
 }
@@ -248,34 +250,45 @@ func scanProcessSockets(pid int) []inodeEntry {
 
 func getProcessInfo(pid int) (*processInfo, error) {
 	info := &processInfo{pid: pid}
+	pidStr := strconv.Itoa(pid)
 
-	commPath := filepath.Join("/proc", strconv.Itoa(pid), "comm")
+	commPath := filepath.Join("/proc", pidStr, "comm")
 	commData, err := os.ReadFile(commPath)
 	if err == nil && len(commData) > 0 {
 		info.command = strings.TrimSpace(string(commData))
 	}
 
-	if info.command == "" {
-		cmdlinePath := filepath.Join("/proc", strconv.Itoa(pid), "cmdline")
-		cmdlineData, err := os.ReadFile(cmdlinePath)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(cmdlineData) > 0 {
-			parts := bytes.Split(cmdlineData, []byte{0})
-			if len(parts) > 0 && len(parts[0]) > 0 {
-				fullPath := string(parts[0])
-				baseName := filepath.Base(fullPath)
-				if strings.Contains(baseName, " ") {
-					baseName = strings.Fields(baseName)[0]
-				}
-				info.command = baseName
+	cmdlinePath := filepath.Join("/proc", pidStr, "cmdline")
+	cmdlineData, err := os.ReadFile(cmdlinePath)
+	if err == nil && len(cmdlineData) > 0 {
+		parts := bytes.Split(cmdlineData, []byte{0})
+		var args []string
+		for _, p := range parts {
+			if len(p) > 0 {
+				args = append(args, string(p))
 			}
 		}
+		info.cmdline = strings.Join(args, " ")
+
+		if info.command == "" && len(parts) > 0 && len(parts[0]) > 0 {
+			fullPath := string(parts[0])
+			baseName := filepath.Base(fullPath)
+			if strings.Contains(baseName, " ") {
+				baseName = strings.Fields(baseName)[0]
+			}
+			info.command = baseName
+		}
+	} else if info.command == "" {
+		return nil, err
 	}
 
-	statusPath := filepath.Join("/proc", strconv.Itoa(pid), "status")
+	cwdPath := filepath.Join("/proc", pidStr, "cwd")
+	cwdLink, err := os.Readlink(cwdPath)
+	if err == nil {
+		info.cwd = cwdLink
+	}
+
+	statusPath := filepath.Join("/proc", pidStr, "status")
 	statusFile, err := os.Open(statusPath)
 	if err != nil {
 		return info, nil
@@ -361,6 +374,8 @@ func parseProcNet(path, proto string, ipVersion int, inodeMap map[int64]*process
 		if procInfo, exists := inodeMap[inode]; exists {
 			conn.PID = procInfo.pid
 			conn.Process = procInfo.command
+			conn.Cmdline = procInfo.cmdline
+			conn.Cwd = procInfo.cwd
 			conn.UID = procInfo.uid
 			conn.User = procInfo.user
 		}

--- a/internal/collector/sort_test.go
+++ b/internal/collector/sort_test.go
@@ -128,3 +128,75 @@ func TestSortByTimestamp(t *testing.T) {
 	}
 }
 
+func TestSortByRemoteAddr(t *testing.T) {
+	conns := []Connection{
+		{Raddr: "192.168.1.100", Rport: 443},
+		{Raddr: "10.0.0.1", Rport: 80},
+		{Raddr: "172.16.0.50", Rport: 8080},
+	}
+
+	t.Run("sort by raddr ascending", func(t *testing.T) {
+		c := make([]Connection, len(conns))
+		copy(c, conns)
+
+		SortConnections(c, SortOptions{Field: SortByRaddr, Direction: SortAsc})
+
+		if c[0].Raddr != "10.0.0.1" {
+			t.Errorf("expected '10.0.0.1' first, got '%s'", c[0].Raddr)
+		}
+		if c[1].Raddr != "172.16.0.50" {
+			t.Errorf("expected '172.16.0.50' second, got '%s'", c[1].Raddr)
+		}
+		if c[2].Raddr != "192.168.1.100" {
+			t.Errorf("expected '192.168.1.100' last, got '%s'", c[2].Raddr)
+		}
+	})
+
+	t.Run("sort by raddr descending", func(t *testing.T) {
+		c := make([]Connection, len(conns))
+		copy(c, conns)
+
+		SortConnections(c, SortOptions{Field: SortByRaddr, Direction: SortDesc})
+
+		if c[0].Raddr != "192.168.1.100" {
+			t.Errorf("expected '192.168.1.100' first, got '%s'", c[0].Raddr)
+		}
+	})
+}
+
+func TestSortByRemotePort(t *testing.T) {
+	conns := []Connection{
+		{Raddr: "192.168.1.1", Rport: 443},
+		{Raddr: "192.168.1.2", Rport: 80},
+		{Raddr: "192.168.1.3", Rport: 8080},
+	}
+
+	t.Run("sort by rport ascending", func(t *testing.T) {
+		c := make([]Connection, len(conns))
+		copy(c, conns)
+
+		SortConnections(c, SortOptions{Field: SortByRport, Direction: SortAsc})
+
+		if c[0].Rport != 80 {
+			t.Errorf("expected port 80 first, got %d", c[0].Rport)
+		}
+		if c[1].Rport != 443 {
+			t.Errorf("expected port 443 second, got %d", c[1].Rport)
+		}
+		if c[2].Rport != 8080 {
+			t.Errorf("expected port 8080 last, got %d", c[2].Rport)
+		}
+	})
+
+	t.Run("sort by rport descending", func(t *testing.T) {
+		c := make([]Connection, len(conns))
+		copy(c, conns)
+
+		SortConnections(c, SortOptions{Field: SortByRport, Direction: SortDesc})
+
+		if c[0].Rport != 8080 {
+			t.Errorf("expected port 8080 first, got %d", c[0].Rport)
+		}
+	})
+}
+

--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -6,6 +6,8 @@ type Connection struct {
 	TS         time.Time `json:"ts"`
 	PID        int       `json:"pid"`
 	Process    string    `json:"process"`
+	Cmdline    string    `json:"cmdline,omitempty"`
+	Cwd        string    `json:"cwd,omitempty"`
 	User       string    `json:"user"`
 	UID        int       `json:"uid"`
 	Proto      string    `json:"proto"`

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -38,6 +38,10 @@ func sortFieldLabel(f collector.SortField) string {
 		return "state"
 	case collector.SortByProto:
 		return "proto"
+	case collector.SortByRaddr:
+		return "raddr"
+	case collector.SortByRport:
+		return "rport"
 	default:
 		return "port"
 	}

--- a/internal/tui/symbols.go
+++ b/internal/tui/symbols.go
@@ -33,6 +33,8 @@ const (
 	BoxCross    = string('\u253C') // light vertical and horizontal
 
 	// misc
-	SymbolDash = string('\u2013') // en dash
+	SymbolDash   = string('\u2013') // en dash
+	SymbolExport = string('\u21E5') // rightwards arrow to bar
+	SymbolPrompt = string('\u276F') // heavy right-pointing angle quotation mark ornament
 )
 


### PR DESCRIPTION
fixes #20 #21 #22 #23

- search now matches against port numbers and pid (so /3000 finds connections on port 3000)
- sort cycle includes remote address and remote port options
- export modal in tui lets you pick csv or tsv format and shows a preview of what will be exported
- added -O/--output-file flag to snitch ls for cli export
- connections include cmdline and cwd fields, visible in detail view and json output

tested on linux, includes unit tests for all changes.